### PR TITLE
Update selection colors

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -132,11 +132,11 @@ for (let [flavour, colors] of Object.entries(variants)) {
     },
     {
       key: "Selection Color",
-      col: colors.rosewater,
+      col: colors.surface2,
     },
     {
       key: "Selected Text Color",
-      col: colors.crust,
+      col: colors.text,
     },
   ];
   const compiled = Handlebars.compile(template);

--- a/colors/catppuccin-frappe.itermcolors
+++ b/colors/catppuccin-frappe.itermcolors
@@ -306,11 +306,11 @@
     <key>Color Space</key>
     <string>sRGB</string>
     <key>Red Component</key>
-    <real>0.9490196078431372</real>
+    <real>0.3843137254901961</real>
     <key>Green Component</key>
-    <real>0.8352941176470589</real>
+    <real>0.40784313725490196</real>
     <key>Blue Component</key>
-    <real>0.8117647058823529</real>
+    <real>0.5019607843137255</real>
     <key>Alpha Component</key>
     <real>1</real>
   </dict>
@@ -319,11 +319,11 @@
     <key>Color Space</key>
     <string>sRGB</string>
     <key>Red Component</key>
-    <real>0.13725490196078433</real>
+    <real>0.7764705882352941</real>
     <key>Green Component</key>
-    <real>0.14901960784313725</real>
+    <real>0.8156862745098039</real>
     <key>Blue Component</key>
-    <real>0.20392156862745098</real>
+    <real>0.9607843137254902</real>
     <key>Alpha Component</key>
     <real>1</real>
   </dict>

--- a/colors/catppuccin-latte.itermcolors
+++ b/colors/catppuccin-latte.itermcolors
@@ -306,11 +306,11 @@
     <key>Color Space</key>
     <string>sRGB</string>
     <key>Red Component</key>
-    <real>0.8627450980392157</real>
+    <real>0.6745098039215687</real>
     <key>Green Component</key>
-    <real>0.5411764705882353</real>
+    <real>0.6901960784313725</real>
     <key>Blue Component</key>
-    <real>0.47058823529411764</real>
+    <real>0.7450980392156863</real>
     <key>Alpha Component</key>
     <real>1</real>
   </dict>
@@ -319,11 +319,11 @@
     <key>Color Space</key>
     <string>sRGB</string>
     <key>Red Component</key>
-    <real>0.8627450980392157</real>
+    <real>0.2980392156862745</real>
     <key>Green Component</key>
-    <real>0.8784313725490196</real>
+    <real>0.30980392156862746</real>
     <key>Blue Component</key>
-    <real>0.9098039215686274</real>
+    <real>0.4117647058823529</real>
     <key>Alpha Component</key>
     <real>1</real>
   </dict>

--- a/colors/catppuccin-macchiato.itermcolors
+++ b/colors/catppuccin-macchiato.itermcolors
@@ -306,11 +306,11 @@
     <key>Color Space</key>
     <string>sRGB</string>
     <key>Red Component</key>
-    <real>0.9568627450980393</real>
+    <real>0.3568627450980392</real>
     <key>Green Component</key>
-    <real>0.8588235294117647</real>
+    <real>0.3764705882352941</real>
     <key>Blue Component</key>
-    <real>0.8392156862745098</real>
+    <real>0.47058823529411764</real>
     <key>Alpha Component</key>
     <real>1</real>
   </dict>
@@ -319,11 +319,11 @@
     <key>Color Space</key>
     <string>sRGB</string>
     <key>Red Component</key>
-    <real>0.09411764705882353</real>
+    <real>0.792156862745098</real>
     <key>Green Component</key>
-    <real>0.09803921568627451</real>
+    <real>0.8274509803921568</real>
     <key>Blue Component</key>
-    <real>0.14901960784313725</real>
+    <real>0.9607843137254902</real>
     <key>Alpha Component</key>
     <real>1</real>
   </dict>

--- a/colors/catppuccin-mocha.itermcolors
+++ b/colors/catppuccin-mocha.itermcolors
@@ -306,11 +306,11 @@
     <key>Color Space</key>
     <string>sRGB</string>
     <key>Red Component</key>
-    <real>0.9607843137254902</real>
+    <real>0.34509803921568627</real>
     <key>Green Component</key>
-    <real>0.8784313725490196</real>
+    <real>0.3568627450980392</real>
     <key>Blue Component</key>
-    <real>0.8627450980392157</real>
+    <real>0.4392156862745098</real>
     <key>Alpha Component</key>
     <real>1</real>
   </dict>
@@ -319,11 +319,11 @@
     <key>Color Space</key>
     <string>sRGB</string>
     <key>Red Component</key>
-    <real>0.06666666666666667</real>
+    <real>0.803921568627451</real>
     <key>Green Component</key>
-    <real>0.06666666666666667</real>
+    <real>0.8392156862745098</real>
     <key>Blue Component</key>
-    <real>0.10588235294117647</real>
+    <real>0.9568627450980393</real>
     <key>Alpha Component</key>
     <real>1</real>
   </dict>


### PR DESCRIPTION
Update selection color to surface2 and selected text color to be the normal text color. (Before it was crust on rosewater.)

<img width="379" alt="image" src="https://user-images.githubusercontent.com/19734415/200209277-4888e852-ff7b-4b09-b5ae-07ae01491ea8.png">
