### PR TITLE
fix: use base for cursor text

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -124,7 +124,7 @@ for (let [flavour, colors] of Object.entries(variants)) {
     },
     {
       key: "Cursor Text Color",
-      col: colors.text,
+      col: colors.base,
     },
     {
       key: "Cursor Guide Color",

--- a/colors/catppuccin-frappe.itermcolors
+++ b/colors/catppuccin-frappe.itermcolors
@@ -280,11 +280,11 @@
     <key>Color Space</key>
     <string>sRGB</string>
     <key>Red Component</key>
-    <real>0.7764705882352941</real>
+    <real>0.18823529411764706</real>
     <key>Green Component</key>
-    <real>0.8156862745098039</real>
+    <real>0.20392156862745098</real>
     <key>Blue Component</key>
-    <real>0.9607843137254902</real>
+    <real>0.27450980392156865</real>
     <key>Alpha Component</key>
     <real>1</real>
   </dict>

--- a/colors/catppuccin-latte.itermcolors
+++ b/colors/catppuccin-latte.itermcolors
@@ -280,11 +280,11 @@
     <key>Color Space</key>
     <string>sRGB</string>
     <key>Red Component</key>
-    <real>0.2980392156862745</real>
+    <real>0.9372549019607843</real>
     <key>Green Component</key>
-    <real>0.30980392156862746</real>
+    <real>0.9450980392156862</real>
     <key>Blue Component</key>
-    <real>0.4117647058823529</real>
+    <real>0.9607843137254902</real>
     <key>Alpha Component</key>
     <real>1</real>
   </dict>

--- a/colors/catppuccin-macchiato.itermcolors
+++ b/colors/catppuccin-macchiato.itermcolors
@@ -280,11 +280,11 @@
     <key>Color Space</key>
     <string>sRGB</string>
     <key>Red Component</key>
-    <real>0.792156862745098</real>
+    <real>0.1411764705882353</real>
     <key>Green Component</key>
-    <real>0.8274509803921568</real>
+    <real>0.15294117647058825</real>
     <key>Blue Component</key>
-    <real>0.9607843137254902</real>
+    <real>0.22745098039215686</real>
     <key>Alpha Component</key>
     <real>1</real>
   </dict>

--- a/colors/catppuccin-mocha.itermcolors
+++ b/colors/catppuccin-mocha.itermcolors
@@ -280,11 +280,11 @@
     <key>Color Space</key>
     <string>sRGB</string>
     <key>Red Component</key>
-    <real>0.803921568627451</real>
+    <real>0.11764705882352941</real>
     <key>Green Component</key>
-    <real>0.8392156862745098</real>
+    <real>0.11764705882352941</real>
     <key>Blue Component</key>
-    <real>0.9568627450980393</real>
+    <real>0.1803921568627451</real>
     <key>Alpha Component</key>
     <real>1</real>
   </dict>


### PR DESCRIPTION
The cursor text was very hard to see against the cursor background. I've updated the cursor text to use `base` as the alacritty theme does.

before:
<img width="82" alt="before" src="https://github.com/catppuccin/iterm/assets/8225950/03377e5e-b8d8-46a8-8f86-2ac5ca2e954f">

after:
<img width="82" alt="after" src="https://github.com/catppuccin/iterm/assets/8225950/a27545d1-c48b-4a6b-8480-4bf011e6d666">
